### PR TITLE
Bugfix/vpn decorator with multhreaded data loader

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,7 @@
         <configuration>
           <excludes>
             <exclude>**technology/dice/dicewhere/lineprocessing/serializers/protobuf/*</exclude>
+            <exclude>**technology/dice/dicewhere/decorator/serializers/protobuf/*</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>technology.dice.open</groupId>
   <artifactId>dice-where</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <name>dice-where</name>
 
   <description>dice-where is a low memory footprint, highly efficient

--- a/src/main/java/technology/dice/dicewhere/api/exceptions/DecoratorDatabaseOutOfOrderException.java
+++ b/src/main/java/technology/dice/dicewhere/api/exceptions/DecoratorDatabaseOutOfOrderException.java
@@ -7,7 +7,12 @@
 package technology.dice.dicewhere.api.exceptions;
 
 public class DecoratorDatabaseOutOfOrderException extends RuntimeException {
-	public DecoratorDatabaseOutOfOrderException(String message) {
-		super(message);
-	}
+
+  public DecoratorDatabaseOutOfOrderException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DecoratorDatabaseOutOfOrderException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
+++ b/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
@@ -59,7 +59,7 @@ public class DatabaseBuilder implements Runnable {
     expectingMore = false;
   }
 
-  public int reimainingLines() {
+  public int remainingLines() {
     return source.size();
   }
 

--- a/src/main/java/technology/dice/dicewhere/decorator/Decorator.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/Decorator.java
@@ -59,10 +59,24 @@ public abstract class Decorator<T extends DecoratorInformation> {
    */
   public Stream<IpInformation> decorate(IpInformation original) throws UnknownHostException {
     Objects.requireNonNull(original);
-    List<List<T>> extraInformation = databaseReaders.entrySet().stream().map(e -> e.getValue().fetchForRange(original.getStartOfRange(), original.getEndOfRange())).collect(ImmutableList.toImmutableList());
+    //    try {
+    List<List<T>> extraInformation =
+        databaseReaders
+            .entrySet()
+            .stream()
+            .map(
+                e ->
+                    e.getValue()
+                        .fetchForRange(original.getStartOfRange(), original.getEndOfRange()))
+            .collect(ImmutableList.toImmutableList());
 
     return this.mergeIpInfoWithDecoratorInformation(
         original, mergeDecorationRanges(extraInformation));
+    //    } catch (Exception e) {
+    //      // TODO: tidy up debug code
+    //      e.printStackTrace();
+    //      throw new RuntimeException(e);
+    //    }
   }
 
   private List<T> mergeDecorationRanges(Collection<List<T>> found) throws UnknownHostException {

--- a/src/main/java/technology/dice/dicewhere/decorator/DecoratorDbReader.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/DecoratorDbReader.java
@@ -105,7 +105,6 @@ public abstract class DecoratorDbReader<T extends DecoratorInformation> {
       if (entry.get().getValue().getRangeStart().isGreaterThan(rangeBoundEnd)) {
         break;
       }
-
       entry
           .flatMap(e -> fitToRange(e.getValue(), rangeBoundStart, rangeBoundEnd))
           .ifPresent(result::add);

--- a/src/main/java/technology/dice/dicewhere/decorator/DecoratorDbReader.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/DecoratorDbReader.java
@@ -7,128 +7,147 @@
 package technology.dice.dicewhere.decorator;
 
 import com.google.common.collect.ImmutableList;
+import org.mapdb.DB;
+import org.mapdb.DBException;
+import org.mapdb.DBMaker;
 import technology.dice.dicewhere.api.api.IP;
 import technology.dice.dicewhere.api.exceptions.DecoratorDatabaseOutOfOrderException;
+import technology.dice.dicewhere.lineprocessing.serializers.IPSerializer;
 import technology.dice.dicewhere.utils.IPUtils;
 
+import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Stream;
 
 /**
  * Reads one line at a time from the provided DB. Only hold one line in memory and stop reading when
  * an IP is reached, that is outside of the requested one
  *
- * <p>T lastFetched holds the last line that was read from the DB The reader will keep reading
- * until it reaches the end of the file or the end of the requested ip range;
+ * <p>T lastFetched holds the last line that was read from the DB The reader will keep reading until
+ * it reaches the end of the file or the end of the requested ip range;
  */
 public abstract class DecoratorDbReader<T extends DecoratorInformation> {
-  private T lastFetched;
+  private NavigableMap<IP, T> db;
 
-  protected Optional<T> getLastFetched() {
-    return Optional.ofNullable(lastFetched);
-  }
+  protected abstract void prepareDataSource() throws IOException;
 
-  /**
-   * The last successfully parsed line read from the provided decorating DB
-   * @param lastFetched set the last fetched line to the passed argument
-   */
-  protected void setLastFetched(T lastFetched) {
-    this.lastFetched = lastFetched;
+  protected void init() throws IOException {
+    prepareDataSource();
+    DB db =
+        DBMaker.tempFileDB()
+            .checksumHeaderBypass()
+            .fileLockDisable()
+            .fileMmapEnable()
+            .fileChannelEnable()
+            .transactionEnable()
+            .fileDeleteAfterClose()
+            .make();
+
+    DB.TreeMapSink<IP, T> sink =
+        db.treeMap(
+                this.getClass().getName(),
+                new IPSerializer(),
+                new DecoratorInformationSerializer<T>())
+            .createFromSink();
+
+    Optional<T> prevDbValue = Optional.empty();
+    for (; ; ) {
+      Optional<T> nextLine = readNextLine();
+      try {
+        if (!nextLine.isPresent()) {
+          break;
+        }
+        T dbValue = nextLine.get();
+        if (prevDbValue
+            .map(pv -> dbValue.getRangeStart().isGreaterThan(pv.getRangeEnd()))
+            .orElse(true)) {
+          prevDbValue = Optional.of(dbValue);
+          sink.put(dbValue.getRangeStart(), dbValue);
+        } else {
+          throw new DecoratorDatabaseOutOfOrderException(
+              String.format(
+                  "DB out of order for IP range %s - %s",
+                  IPUtils.from(nextLine.get().getRangeStart()),
+                  IPUtils.from(nextLine.get().getRangeEnd())));
+        }
+      } catch (DBException.NotSorted e) {
+        throw new DecoratorDatabaseOutOfOrderException(
+            String.format(
+                "DB out of order for IP range %s - %s",
+                IPUtils.from(nextLine.get().getRangeStart()),
+                IPUtils.from(nextLine.get().getRangeEnd())));
+      }
+    }
+    this.db = sink.create();
   }
 
   // TODO: javadoc
   public final List<T> fetchForRange(IP rangeBoundStart, IP rangeBoundEnd) {
-    if (!getLastFetched().isPresent()) {
-      return ImmutableList.of();
-    }
+    Objects.requireNonNull(db);
     Stream.Builder<T> result = Stream.builder();
-    do {
-      Optional<T> resultRange =
-          getLastFetched().flatMap(l -> fitToRange(l, rangeBoundStart, rangeBoundEnd));
-      if (resultRange.isPresent()) {
-        result.add(resultRange.get());
-        if (isLastLineRangeContainingTargetRange(rangeBoundStart, rangeBoundEnd)) {
-          break;
-        }
-      }
-      if (!isFinishingAfter(rangeBoundEnd)) {
-        Optional<T> lastReadLine = readNextLine();
-        if (lastReadLine.isPresent() && getLastFetched().isPresent()) {
-          if (lastReadLine
-              .get()
-              .getRangeStart()
-              .isLowerThanOrEqual(getLastFetched().get().getRangeEnd())) {
-            try {
-            throw new DecoratorDatabaseOutOfOrderException(
-                String.format(
-                    "Ranges out of line for %s - %s",
-                    IPUtils.from(lastReadLine.get().getRangeStart()),
-                    IPUtils.from(lastReadLine.get().getRangeEnd())));
-            } catch (UnknownHostException e) {
-              throw new RuntimeException(e);
-            }
-          }
-        }
-        this.setLastFetched(lastReadLine.orElse(null));
-      }
-    } while (isLastLineBeforeRange(rangeBoundEnd)
-        || isLastLineInRange(rangeBoundStart, rangeBoundEnd));
+    IP seekStart = rangeBoundStart;
+    Optional<Map.Entry<IP, T>> biggestPriorToRange =
+        Optional.ofNullable(this.db.floorEntry(seekStart));
+    if (biggestPriorToRange.isPresent()
+        && biggestPriorToRange.get().getValue().getRangeEnd().isGreaterThanOrEqual(seekStart)) {
 
+      seekStart = biggestPriorToRange.get().getValue().getRangeEnd();
+      biggestPriorToRange
+          .flatMap(e -> fitToRange(e.getValue(), rangeBoundStart, rangeBoundEnd))
+          .ifPresent(result::add);
+    }
+    for (; ; ) {
+      Optional<Map.Entry<IP, T>> entry = Optional.ofNullable(this.db.ceilingEntry(seekStart));
+      if (!entry.isPresent()) {
+        break;
+      }
+      if (entry.get().getValue().getRangeStart().isGreaterThan(rangeBoundEnd)) {
+        break;
+      }
+
+      entry
+          .flatMap(e -> fitToRange(e.getValue(), rangeBoundStart, rangeBoundEnd))
+          .ifPresent(result::add);
+      if (entry.get().getValue().getRangeEnd().isGreaterThan(seekStart)) {
+        try {
+          seekStart = IPUtils.increment(entry.get().getValue().getRangeEnd());
+        } catch (UnknownHostException e) {
+          // This is unlikely but if happens it indicates the DB is corrupted containing invalid
+          // data. All records should be in ascending order
+          throw new RuntimeException(e);
+        }
+      } else {
+        break;
+      }
+    }
     return result.build().collect(ImmutableList.toImmutableList());
   }
 
   protected abstract Optional<T> readNextLine();
 
-  private boolean isLastLineRangeContainingTargetRange(IP targetRangeStart, IP targetRangeEnd) {
-    return getLastFetched()
-        .map(
-            a ->
-                a.getRangeStart().isLowerThanOrEqual(targetRangeStart)
-                    && a.getRangeEnd().isGreaterThanOrEqual(targetRangeEnd))
-        .orElse(false);
+  private boolean isLastLineBeforeRange(T dbEntry, IP targetRangeStart) {
+    return targetRangeStart.isGreaterThan(dbEntry.getRangeEnd());
   }
 
-  private boolean isLastLineBeforeRange(IP targetRangeStart) {
-    return getLastFetched().map(a -> targetRangeStart.isGreaterThan(a.getRangeEnd())).orElse(false);
-  }
-
-  private boolean isLastLineAfterRange(IP targetEndStart) {
-    return getLastFetched().map(a -> targetEndStart.isLowerThan(a.getRangeStart())).orElse(false);
-  }
-
-  private boolean isLastLineInRange(IP targetRangeStart, IP targetRangeEnd) {
-    return getLastFetched()
-        .map(
-            a -> {
-              IP lastFetchedRangeStart = a.getRangeStart();
-              IP lastFetchedRangeEnd = a.getRangeEnd();
-              return (targetRangeStart.isLowerThanOrEqual(lastFetchedRangeStart)
-                      && targetRangeEnd.isGreaterThanOrEqual(lastFetchedRangeStart))
-                  || (targetRangeStart.isLowerThanOrEqual(lastFetchedRangeEnd)
-                      && targetRangeEnd.isGreaterThanOrEqual(lastFetchedRangeEnd));
-            })
-        .orElse(false);
-  }
-
-  private boolean isFinishingAfter(IP targetRangeEnd) {
-    return getLastFetched().map(a -> a.getRangeEnd().isGreaterThan(targetRangeEnd)).orElse(false);
+  private boolean isLastLineAfterRange(T dbEntry, IP targetEndStart) {
+    return targetEndStart.isLowerThan(dbEntry.getRangeStart());
   }
 
   /**
    * crops the range of the T to the currently requested range, if it's outside of it.
    *
-   * @param lastLine
+   * @param dbEntry
    * @param rangeLowerBound
    * @param rangeUpperBound
    * @return
    */
-  private Optional<T> fitToRange(T lastLine, IP rangeLowerBound, IP rangeUpperBound) {
-    IP lastLineLowerBound = lastLine.getRangeStart();
-    IP lastLineUpperBound = lastLine.getRangeEnd();
+  private Optional<T> fitToRange(T dbEntry, IP rangeLowerBound, IP rangeUpperBound) {
+    IP lastLineLowerBound = dbEntry.getRangeStart();
+    IP lastLineUpperBound = dbEntry.getRangeEnd();
 
-    if (isLastLineBeforeRange(rangeLowerBound) || isLastLineAfterRange(rangeUpperBound)) {
+    if (isLastLineBeforeRange(dbEntry, rangeLowerBound)
+        || isLastLineAfterRange(dbEntry, rangeUpperBound)) {
       return Optional.empty();
     }
 
@@ -142,9 +161,9 @@ public abstract class DecoratorDbReader<T extends DecoratorInformation> {
       toModify = true;
     }
     if (!toModify) {
-      return Optional.of(lastLine);
+      return Optional.of(dbEntry);
     } else {
-      return Optional.of(updateRange(lastLine, lastLineLowerBound, lastLineUpperBound));
+      return Optional.of(updateRange(dbEntry, lastLineLowerBound, lastLineUpperBound));
     }
   }
 

--- a/src/main/java/technology/dice/dicewhere/decorator/DecoratorInformation.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/DecoratorInformation.java
@@ -8,12 +8,11 @@ package technology.dice.dicewhere.decorator;
 
 import technology.dice.dicewhere.api.api.IP;
 
-import java.io.Serializable;
 
 /**
  * Minimum set of information for each decorating object.
  */
-public interface DecoratorInformation extends Serializable {
+public interface DecoratorInformation {
 
   IP getRangeStart();
 
@@ -24,5 +23,8 @@ public interface DecoratorInformation extends Serializable {
   <T extends DecoratorInformation> T withNewRange(IP start, IP end);
 
   <T extends DecoratorInformation> T withNumberOfMatches(int i);
+
+  byte[] toByteArray();
+
 
 }

--- a/src/main/java/technology/dice/dicewhere/decorator/DecoratorInformation.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/DecoratorInformation.java
@@ -8,10 +8,12 @@ package technology.dice.dicewhere.decorator;
 
 import technology.dice.dicewhere.api.api.IP;
 
+import java.io.Serializable;
+
 /**
  * Minimum set of information for each decorating object.
  */
-public interface DecoratorInformation {
+public interface DecoratorInformation extends Serializable {
 
   IP getRangeStart();
 

--- a/src/main/java/technology/dice/dicewhere/decorator/DecoratorInformationSerializer.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/DecoratorInformationSerializer.java
@@ -1,0 +1,46 @@
+package technology.dice.dicewhere.decorator;
+
+import org.jetbrains.annotations.NotNull;
+import org.mapdb.DataInput2;
+import org.mapdb.DataOutput2;
+import org.mapdb.serializer.GroupSerializerObjectArray;
+
+import java.io.*;
+
+public class DecoratorInformationSerializer<T extends DecoratorInformation>
+    extends GroupSerializerObjectArray<T> {
+
+  @Override
+  public void serialize(
+      @NotNull DataOutput2 dataOutput2, @NotNull T decoratorInformation)
+      throws IOException {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ObjectOutputStream oos = new ObjectOutputStream(bos);
+    oos.writeObject(decoratorInformation);
+    oos.flush();
+    byte[] data = bos.toByteArray();
+    dataOutput2.packInt(data.length);
+    dataOutput2.write(data);
+  }
+
+  @Override
+  public T deserialize(@NotNull DataInput2 dataInput2, int i)
+      throws IOException {
+    int size = dataInput2.unpackInt();
+    byte[] ret = new byte[size];
+    dataInput2.readFully(ret);
+
+    ByteArrayInputStream bis = new ByteArrayInputStream(ret);
+    ObjectInput in = null;
+    try {
+      in = new ObjectInputStream(bis);
+      return (T) in.readObject();
+    } catch (ClassNotFoundException e) {
+      throw new IOException(e);
+    } finally {
+      if (in != null) {
+        in.close();
+      }
+    }
+  }
+}

--- a/src/main/java/technology/dice/dicewhere/decorator/VpnDecoratorInformation.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/VpnDecoratorInformation.java
@@ -6,7 +6,9 @@
 
 package technology.dice.dicewhere.decorator;
 
+import com.google.protobuf.ByteString;
 import technology.dice.dicewhere.api.api.IP;
+import technology.dice.dicewhere.decorator.serializers.protobuf.VpnDecoratorInformationProtoOuterClass;
 
 import java.util.Objects;
 
@@ -48,6 +50,15 @@ public class VpnDecoratorInformation implements DecoratorInformation {
   @Override
   public VpnDecoratorInformation withNumberOfMatches(int i) {
     return new VpnDecoratorInformation(rangeStart, rangeEnd, i);
+  }
+
+  @Override
+  public byte[] toByteArray() {
+    return VpnDecoratorInformationProtoOuterClass.VpnDecoratorInformationProto
+            .newBuilder()
+            .setStartOfRange(ByteString.copyFrom(rangeStart.getBytes()))
+            .setEndOfRange(ByteString.copyFrom(rangeEnd.getBytes()))
+            .build().toByteArray();
   }
 
   @Override

--- a/src/main/java/technology/dice/dicewhere/lineprocessing/LineProcessor.java
+++ b/src/main/java/technology/dice/dicewhere/lineprocessing/LineProcessor.java
@@ -46,6 +46,7 @@ public class LineProcessor implements Runnable {
    * @param parser the parser to use for parsing the line data
    * @param retainOriginalLine indicates if the original line data should be retained alongside the
    *     serialized data
+   * @param workersCount numbers of threads to use whilst reading from the db file.
    * @param progressListener the listener for reporting progress
    */
   public LineProcessor(

--- a/src/main/java/technology/dice/dicewhere/parsing/LineParser.java
+++ b/src/main/java/technology/dice/dicewhere/parsing/LineParser.java
@@ -25,8 +25,9 @@ public abstract class LineParser {
     IpInformation parsedInfo = this.parseLine(rawLine, retainOriginalLine);
     try {
       return decorateParsedLine(parsedInfo, rawLine);
-    } catch (UnknownHostException e) {
-      // may be we need another exception here, as this will be triggered by the decorators
+    } catch (Exception e) {
+      // This is very general but because it is running in a separate thread,
+      //many exception will just get swallowed making debugging difficult.
       throw new LineParsingException(e, rawLine);
     }
   }

--- a/src/main/java/technology/dice/dicewhere/utils/IPUtils.java
+++ b/src/main/java/technology/dice/dicewhere/utils/IPUtils.java
@@ -27,7 +27,7 @@ public class IPUtils {
 
 	public static IPAddress from(byte[] bytes) throws UnknownHostException {
 		return new IPAddressString(
-				InetAddress.getByAddress(bytes).getCanonicalHostName())
+				InetAddress.getByAddress(bytes).getHostAddress())
 				.getAddress();
 	}
 

--- a/src/main/protobuf/VpnDecoratorInformationProto.proto
+++ b/src/main/protobuf/VpnDecoratorInformationProto.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package technology.dice.dicewhere.decorator.serializers.protobuf;
+
+message VpnDecoratorInformationProto {
+    bytes startOfRange = 1;
+    bytes endOfRange = 2;
+}

--- a/src/test/java/technology/dice/dicewhere/decorator/DecoratorTestUtils.java
+++ b/src/test/java/technology/dice/dicewhere/decorator/DecoratorTestUtils.java
@@ -46,15 +46,13 @@ public class DecoratorTestUtils {
           + "1.0.4.0/27,1,1,0,0,0\n"
           + "1.0.5.0/27,1,1,0,0,0\n"
           + "1.0.7.32/28,1,1,0,0,0\n"
-//          + "1.0.7.32/27,1,1,0,0,0\n"
           + "1.0.7.48/28,1,1,0,0,0\n"
           + "1.0.7.72/29,1,1,0,0,0\n"
           + "1.0.7.96/29,1,1,0,0,0\n"
-		  + "1.0.8.32/28,1,1,0,0,0\n"
-//		  + "1.0.8.32/27,1,1,0,0,0\n"
-		  + "1.0.8.48/29,1,1,0,0,0\n"
-		  + "1.0.8.72/29,1,1,0,0,0\n"
-		  + "1.0.8.96/29,1,1,0,0,0";
+          + "1.0.8.32/28,1,1,0,0,0\n"
+          + "1.0.8.48/29,1,1,0,0,0\n"
+          + "1.0.8.72/29,1,1,0,0,0\n"
+          + "1.0.8.96/29,1,1,0,0,0";
 
   public static final String IPv6_LINES_2 =
       "network,is_anonymous,is_anonymous_vpn,is_hosting_provider,is_public_proxy,is_tor_exit_node";
@@ -75,7 +73,7 @@ public class DecoratorTestUtils {
   public static VpnDecorator getMaxmindVpnDecorator(
       DecorationStrategy strategy, List<String> ipv4Lines, List<String> ipv6Lines)
       throws IOException {
-    Stream.Builder<MaxmindVpnDecoratorDbReader> builder = Stream.builder();
+    Stream.Builder<DecoratorDbReader<VpnDecoratorInformation>> builder = Stream.builder();
     for (int i = 0; i < ipv4Lines.size(); i++) {
       builder.add(getMaxmindVpnDecorator(ipv4Lines.get(i), ipv6Lines.get(i)));
     }
@@ -85,7 +83,7 @@ public class DecoratorTestUtils {
   public static VpnDecorator getMaxmindVpnDecorator(DecorationStrategy strategy)
       throws IOException {
     return new VpnDecorator(
-        Stream.<MaxmindVpnDecoratorDbReader>builder()
+        Stream.<DecoratorDbReader<VpnDecoratorInformation>>builder()
             .add(getMaxmindVpnDecorator(IPv4_LINES, IPv6_LINES))
             .add(getMaxmindVpnDecorator(IPv4_LINES_2, IPv6_LINES_2))
             .add(getMaxmindVpnDecorator(IPv4_LINES_3, IPv6_LINES_3))
@@ -94,12 +92,12 @@ public class DecoratorTestUtils {
         strategy);
   }
 
-  public static MaxmindVpnDecoratorDbReader getMaxmindVpnDecorator(
+  public static DecoratorDbReader<VpnDecoratorInformation> getMaxmindVpnDecorator(
       String ipv4Lines, String ipv6Lines) throws IOException {
     InputStream streamV4 = new ByteArrayInputStream(ipv4Lines.getBytes());
     BufferedReader bufferedReaderV4 = new BufferedReader(new InputStreamReader(streamV4));
     InputStream streamV6 = new ByteArrayInputStream(ipv6Lines.getBytes());
     BufferedReader bufferedReaderV6 = new BufferedReader(new InputStreamReader(streamV6));
-    return new MaxmindVpnDecoratorDbReader(bufferedReaderV4, bufferedReaderV6);
+    return MaxmindVpnDecoratorDbReader.of(bufferedReaderV4, bufferedReaderV6);
   }
 }

--- a/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindVpnDecoratorDbReaderTest.java
+++ b/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindVpnDecoratorDbReaderTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import technology.dice.dicewhere.api.api.IP;
 import technology.dice.dicewhere.api.exceptions.DecoratorDatabaseOutOfOrderException;
+import technology.dice.dicewhere.decorator.DecoratorDbReader;
 import technology.dice.dicewhere.decorator.VpnDecoratorInformation;
 import technology.dice.dicewhere.provider.maxmind.decorator.MaxmindVpnDecoratorDbReader;
 
@@ -24,13 +25,12 @@ import java.util.List;
 
 public class MaxmindVpnDecoratorDbReaderTest {
 
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
+  @Rule public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void shouldThrowException_rangesOurOfOrders() throws IOException {
     exception.expect(DecoratorDatabaseOutOfOrderException.class);
-    exception.expectMessage("Ranges out of line for 1.0.7.32 - 1.0.7.63");
+    exception.expectMessage("DB out of order for IP range 1.0.7.32 - 1.0.7.63");
 
     String ipv4Lines =
         "network,is_anonymous,is_anonymous_vpn,is_hosting_provider,is_public_proxy,is_tor_exit_node\n"
@@ -50,18 +50,16 @@ public class MaxmindVpnDecoratorDbReaderTest {
             + "1.0.8.72/29,1,1,0,0,0\n"
             + "1.0.8.96/29,1,1,0,0,0";
     String ipv6Lines =
-            "network,is_anonymous,is_anonymous_vpn,is_hosting_provider,is_public_proxy,is_tor_exit_node";
+        "network,is_anonymous,is_anonymous_vpn,is_hosting_provider,is_public_proxy,is_tor_exit_node";
     InputStream streamV4 = new ByteArrayInputStream(ipv4Lines.getBytes());
     BufferedReader bufferedReaderV4 = new BufferedReader(new InputStreamReader(streamV4));
     InputStream streamV6 = new ByteArrayInputStream(ipv6Lines.getBytes());
     BufferedReader bufferedReaderV6 = new BufferedReader(new InputStreamReader(streamV6));
-    MaxmindVpnDecoratorDbReader parser =
-            new MaxmindVpnDecoratorDbReader(bufferedReaderV4, bufferedReaderV6);
+    DecoratorDbReader<VpnDecoratorInformation> parser =
+        MaxmindVpnDecoratorDbReader.of(bufferedReaderV4, bufferedReaderV6);
     IPAddress inputAddress = new IPAddressString("1.0.7.0/24").getAddress();
-    List<VpnDecoratorInformation> parsedLines =
-            parser.fetchForRange(
-                    new IP(inputAddress.getLower().getBytes()),
-                    new IP(inputAddress.toMaxHost().getBytes()));
+    parser.fetchForRange(
+        new IP(inputAddress.getLower().getBytes()), new IP(inputAddress.toMaxHost().getBytes()));
   }
 
   @Test
@@ -82,8 +80,8 @@ public class MaxmindVpnDecoratorDbReaderTest {
     BufferedReader bufferedReaderV4 = new BufferedReader(new InputStreamReader(streamV4));
     InputStream streamV6 = new ByteArrayInputStream(ipv6Lines.getBytes());
     BufferedReader bufferedReaderV6 = new BufferedReader(new InputStreamReader(streamV6));
-    MaxmindVpnDecoratorDbReader parser =
-        new MaxmindVpnDecoratorDbReader(bufferedReaderV4, bufferedReaderV6);
+    DecoratorDbReader<VpnDecoratorInformation> parser =
+        MaxmindVpnDecoratorDbReader.of(bufferedReaderV4, bufferedReaderV6);
     IPAddress inputAddress = new IPAddressString("1.0.2.0/24").getAddress();
     List<VpnDecoratorInformation> parsedLines =
         parser.fetchForRange(
@@ -118,8 +116,8 @@ public class MaxmindVpnDecoratorDbReaderTest {
     BufferedReader bufferedReaderV4 = new BufferedReader(new InputStreamReader(streamV4));
     InputStream streamV6 = new ByteArrayInputStream(ipv6Lines.getBytes());
     BufferedReader bufferedReaderV6 = new BufferedReader(new InputStreamReader(streamV6));
-    MaxmindVpnDecoratorDbReader parser =
-        new MaxmindVpnDecoratorDbReader(bufferedReaderV4, bufferedReaderV6);
+    DecoratorDbReader<VpnDecoratorInformation> parser =
+        MaxmindVpnDecoratorDbReader.of(bufferedReaderV4, bufferedReaderV6);
     IPAddress inputAddress = new IPAddressString("1.0.2.0/24").getAddress();
     List<VpnDecoratorInformation> parsedLines =
         parser.fetchForRange(
@@ -139,6 +137,8 @@ public class MaxmindVpnDecoratorDbReaderTest {
 
   @Test
   public void shouldParseIPv4_returnNoneBecauseListIsNotOrdered() throws IOException {
+    exception.expect(DecoratorDatabaseOutOfOrderException.class);
+    exception.expectMessage("DB out of order for IP range 1.0.2.16 - 1.0.2.31");
     String ipv4Lines =
         "network,is_anonymous,is_anonymous_vpn,is_hosting_provider,is_public_proxy,is_tor_exit_node\n"
             + "1.0.3.64/28,1,1,0,0,0\n"
@@ -154,15 +154,13 @@ public class MaxmindVpnDecoratorDbReaderTest {
     BufferedReader bufferedReaderV4 = new BufferedReader(new InputStreamReader(streamV4));
     InputStream streamV6 = new ByteArrayInputStream(ipv6Lines.getBytes());
     BufferedReader bufferedReaderV6 = new BufferedReader(new InputStreamReader(streamV6));
-    MaxmindVpnDecoratorDbReader parser =
-        new MaxmindVpnDecoratorDbReader(bufferedReaderV4, bufferedReaderV6);
+    DecoratorDbReader<VpnDecoratorInformation> parser =
+        MaxmindVpnDecoratorDbReader.of(bufferedReaderV4, bufferedReaderV6);
     IPAddress inputAddress = new IPAddressString("1.0.2.0/24").getAddress();
-    List<VpnDecoratorInformation> parsedLines =
         parser.fetchForRange(
             new IP(inputAddress.getLower().getBytes()),
             new IP(inputAddress.toMaxHost().getBytes()));
 
-    Assert.assertTrue(parsedLines.isEmpty());
   }
 
   @Test
@@ -185,8 +183,8 @@ public class MaxmindVpnDecoratorDbReaderTest {
     BufferedReader bufferedReaderV4 = new BufferedReader(new InputStreamReader(streamV4));
     InputStream streamV6 = new ByteArrayInputStream(ipv6Lines.getBytes());
     BufferedReader bufferedReaderV6 = new BufferedReader(new InputStreamReader(streamV6));
-    MaxmindVpnDecoratorDbReader parser =
-        new MaxmindVpnDecoratorDbReader(bufferedReaderV4, bufferedReaderV6);
+    DecoratorDbReader<VpnDecoratorInformation> parser =
+        MaxmindVpnDecoratorDbReader.of(bufferedReaderV4, bufferedReaderV6);
     IPAddress inputAddress = new IPAddressString("2001:470:7:a00::/53").getAddress();
     List<VpnDecoratorInformation> parsedLines =
         parser.fetchForRange(
@@ -219,8 +217,8 @@ public class MaxmindVpnDecoratorDbReaderTest {
     BufferedReader bufferedReaderV4 = new BufferedReader(new InputStreamReader(streamV4));
     InputStream streamV6 = new ByteArrayInputStream(ipv6Lines.getBytes());
     BufferedReader bufferedReaderV6 = new BufferedReader(new InputStreamReader(streamV6));
-    MaxmindVpnDecoratorDbReader parser =
-        new MaxmindVpnDecoratorDbReader(bufferedReaderV4, bufferedReaderV6);
+    DecoratorDbReader<VpnDecoratorInformation> parser =
+        MaxmindVpnDecoratorDbReader.of(bufferedReaderV4, bufferedReaderV6);
     IPAddress inputAddress = new IPAddressString("1.0.2.0/25").getAddress();
     List<VpnDecoratorInformation> parsedLines1 =
         parser.fetchForRange(
@@ -257,11 +255,11 @@ public class MaxmindVpnDecoratorDbReaderTest {
     Assert.assertEquals(expected, parsedLines);
   }
 
-  IP getLowerFromIP(String input) {
+  private IP getLowerFromIP(String input) {
     return new IP(new IPAddressString(input).getAddress().getLower().getBytes());
   }
 
-  IP getMaxHostFromIP(String input) {
+  private IP getMaxHostFromIP(String input) {
     return new IP(new IPAddressString(input).getAddress().toMaxHost().getBytes());
   }
 }


### PR DESCRIPTION
**WHAT**
Currently DecoratorDbReader fails when the requests are coming out or order, which is the case when the initial data is loaded in more than one thread. 
To fix this, this PR loads the whole VPN data in a searchable structure and returns ranges matching the one, being decorated. 
**ISSUE**
This is now much slower due to the searches every time. Previously there now searches just linear reading from a file. 