### PR TITLE
IPInformation decoration prior to building IP DB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>technology.dice.open</groupId>
   <artifactId>dice-where</artifactId>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <name>dice-where</name>
 
   <description>dice-where is a low memory footprint, highly efficient

--- a/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
+++ b/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
@@ -6,8 +6,10 @@
 
 package technology.dice.dicewhere.building;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.Queues;
 
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.protobuf.ByteString;
@@ -31,6 +34,7 @@ import technology.dice.dicewhere.lineprocessing.serializers.IPSerializer;
 import technology.dice.dicewhere.lineprocessing.serializers.protobuf.IPInformationProto;
 import technology.dice.dicewhere.parsing.ParsedLine;
 import technology.dice.dicewhere.provider.ProviderKey;
+import technology.dice.dicewhere.utils.IPUtils;
 import technology.dice.dicewhere.utils.ProtoValueConverter;
 
 public class DatabaseBuilder implements Runnable {
@@ -105,13 +109,12 @@ public class DatabaseBuilder implements Runnable {
             beingProcessed = currentLine;
             decorateEntry(currentLine.getParsedLine().getInfo())
                 .forEach(i -> sink.put(i.getStartOfRange(), buildIpProtobuf(i).toByteArray()));
-            // currentLine.getParsedLine().buildIpProtobuf().toByteArray());
             processedLines++;
             listener.lineAdded(provider, currentLine);
 
           } catch (DBException.NotSorted e) {
             listener.lineOutOfOrder(provider, beingProcessed, e);
-          } catch (UnknownHostException e) {
+          } catch (Exception e) {
             throw new RuntimeException("Database builder interrupted", e);
           }
         }

--- a/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
+++ b/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
@@ -7,19 +7,31 @@
 package technology.dice.dicewhere.building;
 
 import com.google.common.collect.Queues;
+
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import com.google.protobuf.ByteString;
 import org.mapdb.DB;
 import org.mapdb.DBException;
 import org.mapdb.DBMaker;
 import org.mapdb.Serializer;
 import technology.dice.dicewhere.api.api.IP;
+import technology.dice.dicewhere.api.api.IpInformation;
+import technology.dice.dicewhere.decorator.Decorator;
+import technology.dice.dicewhere.decorator.DecoratorInformation;
 import technology.dice.dicewhere.lineprocessing.SerializedLine;
 import technology.dice.dicewhere.lineprocessing.serializers.IPSerializer;
+import technology.dice.dicewhere.lineprocessing.serializers.protobuf.IPInformationProto;
+import technology.dice.dicewhere.parsing.ParsedLine;
 import technology.dice.dicewhere.provider.ProviderKey;
+import technology.dice.dicewhere.utils.ProtoValueConverter;
 
 public class DatabaseBuilder implements Runnable {
   private final BlockingQueue<SerializedLine> source;
@@ -28,12 +40,13 @@ public class DatabaseBuilder implements Runnable {
   private final DB.TreeMapSink<IP, byte[]> sink;
   private boolean expectingMore;
   private int processedLines = 0;
+  private final Decorator<? extends DecoratorInformation> decorator;
 
   public DatabaseBuilder(
       ProviderKey provider,
       BlockingQueue<SerializedLine> source,
-      DatabaseBuilderListener listener) {
-
+      DatabaseBuilderListener listener,
+      Decorator<? extends DecoratorInformation> decorator) {
     this.source = source;
     this.expectingMore = true;
     this.listener = listener;
@@ -53,18 +66,31 @@ public class DatabaseBuilder implements Runnable {
                 Objects.requireNonNull(provider).name(), new IPSerializer(), Serializer.BYTE_ARRAY)
             .createFromSink();
     this.sink = sink;
+    this.decorator = decorator;
+  }
+
+  public DatabaseBuilder(
+      ProviderKey provider,
+      BlockingQueue<SerializedLine> source,
+      DatabaseBuilderListener listener) {
+
+    this(provider, source, listener, null);
   }
 
   public void dontExpectMore() {
     expectingMore = false;
   }
 
-  public int reimainingLines() {
+  public int remainingLines() {
     return source.size();
   }
 
   public int processedLines() {
     return processedLines;
+  }
+
+  protected Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
+    return Optional.ofNullable(decorator);
   }
 
   @Override
@@ -77,12 +103,16 @@ public class DatabaseBuilder implements Runnable {
         for (SerializedLine currentLine : availableForAdding) {
           try {
             beingProcessed = currentLine;
-            sink.put(currentLine.getStartIp(), currentLine.getInfo());
+            decorateEntry(currentLine.getParsedLine().getInfo())
+                .forEach(i -> sink.put(i.getStartOfRange(), buildIpProtobuf(i).toByteArray()));
+            // currentLine.getParsedLine().buildIpProtobuf().toByteArray());
             processedLines++;
             listener.lineAdded(provider, currentLine);
 
           } catch (DBException.NotSorted e) {
             listener.lineOutOfOrder(provider, beingProcessed, e);
+          } catch (UnknownHostException e) {
+            throw new RuntimeException("Database builder interrupted", e);
           }
         }
       } catch (InterruptedException e) {
@@ -90,6 +120,32 @@ public class DatabaseBuilder implements Runnable {
         throw new RuntimeException("Database builder interrupted", e);
       }
     }
+  }
+
+  private Stream<IpInformation> decorateEntry(IpInformation entry) throws UnknownHostException {
+    if (getDecorator().isPresent()) {
+      return getDecorator().get().decorate(entry);
+    } else {
+      return Stream.of(entry);
+    }
+  }
+
+  private IPInformationProto.IpInformationProto buildIpProtobuf(IpInformation input) {
+    IPInformationProto.IpInformationProto.Builder messageBuilder =
+        IPInformationProto.IpInformationProto.newBuilder()
+            .setCity(input.getCity().orElse(""))
+            .setGeonameId(input.getGeonameId().orElse(""))
+            .setCountryCodeAlpha2(input.getCountryCodeAlpha2())
+            .setLeastSpecificDivision(input.getLeastSpecificDivision().orElse(""))
+            .setMostSpecificDivision(input.getMostSpecificDivision().orElse(""))
+            .setPostcode(input.getPostcode().orElse(""))
+            .setStartOfRange(ByteString.copyFrom(input.getStartOfRange().getBytes()))
+            .setEndOfRange(ByteString.copyFrom(input.getEndOfRange().getBytes()))
+            .setIsVpn(ProtoValueConverter.toThreeStateValue(input.isVpn().orElse(null)));
+
+    input.getOriginalLine().ifPresent(messageBuilder::setOriginalLine);
+
+    return messageBuilder.build();
   }
 
   public IPDatabase build() {

--- a/src/main/java/technology/dice/dicewhere/decorator/Decorator.java
+++ b/src/main/java/technology/dice/dicewhere/decorator/Decorator.java
@@ -59,7 +59,15 @@ public abstract class Decorator<T extends DecoratorInformation> {
    */
   public Stream<IpInformation> decorate(IpInformation original) throws UnknownHostException {
     Objects.requireNonNull(original);
-    List<List<T>> extraInformation = databaseReaders.entrySet().stream().map(e -> e.getValue().fetchForRange(original.getStartOfRange(), original.getEndOfRange())).collect(ImmutableList.toImmutableList());
+    List<List<T>> extraInformation =
+        databaseReaders
+            .entrySet()
+            .stream()
+            .map(
+                e ->
+                    e.getValue()
+                        .fetchForRange(original.getStartOfRange(), original.getEndOfRange()))
+            .collect(ImmutableList.toImmutableList());
 
     return this.mergeIpInfoWithDecoratorInformation(
         original, mergeDecorationRanges(extraInformation));

--- a/src/main/java/technology/dice/dicewhere/lineprocessing/SerializedLine.java
+++ b/src/main/java/technology/dice/dicewhere/lineprocessing/SerializedLine.java
@@ -12,20 +12,14 @@ import technology.dice.dicewhere.parsing.ParsedLine;
 public class SerializedLine {
   private ParsedLine parsedLine;
   private final IP startIp;
-  private final byte[] info;
 
-  public SerializedLine(IP startIp, byte[] info, ParsedLine parsedLine) {
+  public SerializedLine(IP startIp, ParsedLine parsedLine) {
     this.startIp = startIp;
-    this.info = info;
     this.parsedLine = parsedLine;
   }
 
   public IP getStartIp() {
     return startIp;
-  }
-
-  public byte[] getInfo() {
-    return info;
   }
 
   public ParsedLine getParsedLine() {

--- a/src/main/java/technology/dice/dicewhere/parsing/LineParser.java
+++ b/src/main/java/technology/dice/dicewhere/parsing/LineParser.java
@@ -18,31 +18,16 @@ import java.util.stream.Stream;
 
 public abstract class LineParser {
 
-  protected abstract Optional<Decorator<? extends DecoratorInformation>> getDecorator();
+  public abstract Optional<Decorator<? extends DecoratorInformation>> getDecorator();
 
   public Stream<ParsedLine> parse(RawLine rawLine, boolean retainOriginalLine)
       throws LineParsingException {
     IpInformation parsedInfo = this.parseLine(rawLine, retainOriginalLine);
-    try {
-      return decorateParsedLine(parsedInfo, rawLine);
-    } catch (UnknownHostException e) {
-      // may be we need another exception here, as this will be triggered by the decorators
-      throw new LineParsingException(e, rawLine);
-    }
+    return Stream.of(
+        new ParsedLine(
+            parsedInfo.getStartOfRange(), parsedInfo.getEndOfRange(), parsedInfo, rawLine));
   }
 
   protected abstract IpInformation parseLine(RawLine rawLine, boolean retainOriginalLine)
       throws LineParsingException;
-
-  private Stream<ParsedLine> decorateParsedLine(IpInformation ipInfo, RawLine rawLine)
-      throws UnknownHostException {
-    if (getDecorator().isPresent()) {
-      Stream<IpInformation> decoratedIpInfo = getDecorator().get().decorate(ipInfo);
-      return decoratedIpInfo.map(
-          info -> new ParsedLine(info.getStartOfRange(), info.getEndOfRange(), info, rawLine));
-    } else {
-      return Stream.of(
-          new ParsedLine(ipInfo.getStartOfRange(), ipInfo.getEndOfRange(), ipInfo, rawLine));
-    }
-  }
 }

--- a/src/main/java/technology/dice/dicewhere/provider/dbip/parsing/DbIpIpToCityLiteCSVLineParser.java
+++ b/src/main/java/technology/dice/dicewhere/provider/dbip/parsing/DbIpIpToCityLiteCSVLineParser.java
@@ -39,7 +39,7 @@ public class DbIpIpToCityLiteCSVLineParser extends LineParser {
   }
 
   @Override
-  protected Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
+  public Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
     return Optional.ofNullable(decorator);
   }
 

--- a/src/main/java/technology/dice/dicewhere/provider/dbip/parsing/DbIpIpToCountryLiteCSVLineParser.java
+++ b/src/main/java/technology/dice/dicewhere/provider/dbip/parsing/DbIpIpToCountryLiteCSVLineParser.java
@@ -39,7 +39,7 @@ public class DbIpIpToCountryLiteCSVLineParser extends LineParser {
   }
 
   @Override
-  protected Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
+  public Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
     return Optional.ofNullable(decorator);
   }
 

--- a/src/main/java/technology/dice/dicewhere/provider/dbip/parsing/DbIpIpToLocationAndIspCSVLineParser.java
+++ b/src/main/java/technology/dice/dicewhere/provider/dbip/parsing/DbIpIpToLocationAndIspCSVLineParser.java
@@ -47,7 +47,7 @@ public class DbIpIpToLocationAndIspCSVLineParser extends LineParser {
   }
 
   @Override
-  protected Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
+  public Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
     return Optional.ofNullable(decorator);
   }
 

--- a/src/main/java/technology/dice/dicewhere/provider/maxmind/parsing/MaxmindLineParser.java
+++ b/src/main/java/technology/dice/dicewhere/provider/maxmind/parsing/MaxmindLineParser.java
@@ -49,7 +49,7 @@ public class MaxmindLineParser extends LineParser {
   }
 
   @Override
-  protected Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
+  public Optional<Decorator<? extends DecoratorInformation>> getDecorator() {
     return Optional.ofNullable(decorator);
   }
 

--- a/src/main/java/technology/dice/dicewhere/reading/LineReader.java
+++ b/src/main/java/technology/dice/dicewhere/reading/LineReader.java
@@ -112,8 +112,7 @@ public abstract class LineReader {
       LineReaderListener readerListener,
       LineProcessorListener processListener,
       DatabaseBuilderListener buildingListener,
-      int workersCount)
-      throws IOException {
+      int workersCount) {
 
     long before = System.currentTimeMillis();
     ExecutorService parserExecutorService =
@@ -134,8 +133,13 @@ public abstract class LineReader {
               retainOriginalLine,
               new LineprocessorListenerForProvider(provider(), processListener),
               workersCount);
+
       DatabaseBuilder databaseBuilder =
-          new DatabaseBuilder(provider(), serializedLinesBuffer, buildingListener);
+          parser()
+              .getDecorator()
+              .map(d -> new DatabaseBuilder(provider(), serializedLinesBuffer, buildingListener, d))
+              .orElseGet(
+                  () -> new DatabaseBuilder(provider(), serializedLinesBuffer, buildingListener));
 
       Future processorFuture = setupExecutorService.submit(processor);
       Future databaseBuilderFuture = setupExecutorService.submit(databaseBuilder);

--- a/src/main/java/technology/dice/dicewhere/utils/IPUtils.java
+++ b/src/main/java/technology/dice/dicewhere/utils/IPUtils.java
@@ -9,26 +9,23 @@ import java.net.UnknownHostException;
 
 public class IPUtils {
 
-	public static IP increment(IP ip) throws UnknownHostException {
-		return increment(ip, 1);
-	}
+  public static IP increment(IP ip) throws UnknownHostException {
+    return increment(ip, 1);
+  }
 
-	public static IP decrement(IP ip) throws UnknownHostException {
-		return increment(ip, -1);
-	}
+  public static IP decrement(IP ip) throws UnknownHostException {
+    return increment(ip, -1);
+  }
 
-	public static IP increment(IP ip, int increment) throws UnknownHostException {
-		return new IP(from(ip.getBytes()).increment(increment).getBytes());
-	}
+  public static IP increment(IP ip, int increment) throws UnknownHostException {
+    return new IP(from(ip.getBytes()).increment(increment).getBytes());
+  }
 
-	public static IPAddress from(IP ip) throws UnknownHostException {
-		return from(ip.getBytes());
-	}
+  public static IPAddress from(IP ip) throws UnknownHostException {
+    return from(ip.getBytes());
+  }
 
-	public static IPAddress from(byte[] bytes) throws UnknownHostException {
-		return new IPAddressString(
-				InetAddress.getByAddress(bytes).getCanonicalHostName())
-				.getAddress();
-	}
-
+  public static IPAddress from(byte[] bytes) throws UnknownHostException {
+    return new IPAddressString(InetAddress.getByAddress(bytes).getHostAddress()).getAddress();
+  }
 }

--- a/src/test/java/technology/dice/dicewhere/decorator/DecoratorTestUtils.java
+++ b/src/test/java/technology/dice/dicewhere/decorator/DecoratorTestUtils.java
@@ -30,7 +30,8 @@ public class DecoratorTestUtils {
           + "1.0.5.32/28,1,1,0,0,0\n"
           + "1.0.7.16/29,1,1,0,0,0\n"
           + "1.0.8.16/29,1,1,0,0,0\n"
-          + "1.0.8.32/29,1,1,0,0,0";
+          + "1.0.8.32/29,1,1,0,0,0\n"
+          + "1.0.32.1/32,1,1,0,0,0";
 
   public static final String IPv6_LINES =
       "network,is_anonymous,is_anonymous_vpn,is_hosting_provider,is_public_proxy,is_tor_exit_node\n"

--- a/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindLineParserTest.java
+++ b/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindLineParserTest.java
@@ -109,7 +109,6 @@ public class MaxmindLineParserTest {
 
   @Test
   public void shouldIdentifyIpv4RangesWithVpn_whenRangesDoNotOverlap() throws IOException {
-
     IPResolver ipdb =
         new IPResolver.Builder()
             .withProvider(

--- a/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindLineParserTest.java
+++ b/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindLineParserTest.java
@@ -8,10 +8,7 @@ package technology.dice.dicewhere.parsing.provider.maxmind;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.InetAddresses;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import technology.dice.dicewhere.api.api.IP;
 import technology.dice.dicewhere.api.api.IpInformation;
 import technology.dice.dicewhere.api.exceptions.LineParsingException;
@@ -105,6 +102,7 @@ public class MaxmindLineParserTest {
   }
 
   @Test
+  @Ignore //DECORATION now happens prior to putting it in the DB
   public void shouldIdentifyIpv4RangesWithVpn_whenRangesDoNotOverlap()
       throws LineParsingException, IOException {
     MaxmindLineParser maxmindLineParser = new MaxmindLineParser(locationNames, DecoratorTestUtils.getMaxmindVpnDecorator(DecorationStrategy.ANY));

--- a/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindLineParserTest.java
+++ b/src/test/java/technology/dice/dicewhere/parsing/provider/maxmind/MaxmindLineParserTest.java
@@ -108,30 +108,28 @@ public class MaxmindLineParserTest {
   }
 
   @Test
-  public void shouldIdentifyIpv4RangesWithVpn_whenRangesDoNotOverlap()
-      throws IOException {
+  public void shouldIdentifyIpv4RangesWithVpn_whenRangesDoNotOverlap() throws IOException {
 
-
-    IPResolver ipdb = new IPResolver.Builder()
+    IPResolver ipdb =
+        new IPResolver.Builder()
             .withProvider(
-                    new MaxmindDbReader(
-                            Paths.get(
-                                    IPResolverTest.class
-                                            .getClassLoader()
-                                            .getResource("provider/maxmind/GeoLite2-City-Locations-en.csv.zip")
-                                            .getFile()),
-                            Paths.get(
-                                    IPResolverTest.class
-                                            .getClassLoader()
-                                            .getResource("provider/maxmind/tinyValidV4.csv")
-                                            .getFile()),
-                            Paths.get(
-                                    IPResolverTest.class
-                                            .getClassLoader()
-                                            .getResource("provider/maxmind/tinyValidV6.csv")
-                                            .getFile()),
-                            DecoratorTestUtils.getMaxmindVpnDecorator(DecorationStrategy.ANY))
-            )
+                new MaxmindDbReader(
+                    Paths.get(
+                        IPResolverTest.class
+                            .getClassLoader()
+                            .getResource("provider/maxmind/GeoLite2-City-Locations-en.csv.zip")
+                            .getFile()),
+                    Paths.get(
+                        IPResolverTest.class
+                            .getClassLoader()
+                            .getResource("provider/maxmind/tinyValidV4.csv")
+                            .getFile()),
+                    Paths.get(
+                        IPResolverTest.class
+                            .getClassLoader()
+                            .getResource("provider/maxmind/tinyValidV6.csv")
+                            .getFile()),
+                    DecoratorTestUtils.getMaxmindVpnDecorator(DecorationStrategy.ANY)))
             .build();
 
     Map<ProviderKey, Optional<IpInformation>> resolvedVpnIp = ipdb.resolve("1.0.32.1");


### PR DESCRIPTION
**WHAT**
To ensure that the decorator db is read in order with the information being put in the ip database

**WHY**
Previously when the location is being read by different threads the requests to the decorator will come out of order which will lead to skipping results or adding results in wrong order. 