### PR TITLE
Dropping transaction support, to prevent WAL Volume file access errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>technology.dice.open</groupId>
   <artifactId>dice-where</artifactId>
-  <version>1.0.6</version>
+  <version>1.0.7</version>
   <name>dice-where</name>
 
   <description>dice-where is a low memory footprint, highly efficient

--- a/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
+++ b/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
@@ -83,13 +83,13 @@ public class DatabaseBuilder implements Runnable {
     DB db;
     switch (storageMode) {
       case HEAP:
-        db = DBMaker.heapDB().checksumHeaderBypass().transactionEnable().make();
+        db = DBMaker.heapDB().checksumHeaderBypass().make();
         break;
       case HEAP_BYTE_ARRAY:
-        db = DBMaker.memoryDB().checksumHeaderBypass().transactionEnable().make();
+        db = DBMaker.memoryDB().checksumHeaderBypass().make();
         break;
       case OFF_HEAP:
-        db = DBMaker.memoryDirectDB().checksumHeaderBypass().transactionEnable().make();
+        db = DBMaker.memoryDirectDB().checksumHeaderBypass().make();
         break;
       case FILE:
       default:

--- a/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
+++ b/src/main/java/technology/dice/dicewhere/building/DatabaseBuilder.java
@@ -99,7 +99,6 @@ public class DatabaseBuilder implements Runnable {
                 .fileLockDisable()
                 .fileMmapEnable()
                 .fileChannelEnable()
-                .transactionEnable()
                 .fileDeleteAfterClose()
                 .make();
         break;


### PR DESCRIPTION
Volume closed issues are raised by WAL log that is used to make sure data is atomic, this library doesn't need this, as it should be used once the data has been build, then it's atomic.

http://www.mapdb.org/book/performance/