### PR TITLE
Do not user Maven settings.xml for Docker Hub auth

### DIFF
--- a/dice-where-downloader/pom.xml
+++ b/dice-where-downloader/pom.xml
@@ -48,7 +48,6 @@
           <buildArgs>
             <JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
           </buildArgs>
-          <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
`useMavenSettingsForAuth` is apparently preventing the push to Docker Hub to work properly when ran under Github Actions.