### PR TITLE
Login explicitly with Docker Hub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,12 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Login to Docker Hub
+        if: ${{ github.ref == 'refs/heads/master' && github.repository == 'DiceTechnology/dice-where' }}
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Set version, sign artifacts and deploy to Maven Central/Docker Hub
         if: ${{ github.ref == 'refs/heads/master' && github.repository == 'DiceTechnology/dice-where' }}
         run: cd/deploy.sh
@@ -40,6 +46,4 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           SLACK_URL: ${{ secrets.SLACK_URL }}

--- a/dice-where-downloader/pom.xml
+++ b/dice-where-downloader/pom.xml
@@ -41,8 +41,6 @@
           </execution>
         </executions>
         <configuration>
-          <username>${env.DOCKER_USER}</username>
-          <password>${env.DOCKER_PASSWORD}</password>
           <repository>dicetechnology/dice-where-downloader</repository>
           <tag>${project.version}</tag>
           <buildArgs>


### PR DESCRIPTION
We now login explicitly against Docker Hub instead of relying on the dockerfile-maven-plugin's credential support, which does not seem to operate properly under the GH Actions environment.

This plugin is not supported anymore and will need to be replaced in the future regardless, so relying on it to pass on the Docker Hub credentials is not a good approach.