### PR TITLE
NO_JIRA - Fix for latest AWS V2 version on localstack S3 - Resolve DNS

### DIFF
--- a/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/destination/s3/S3DownloadSetup.java
+++ b/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/destination/s3/S3DownloadSetup.java
@@ -3,7 +3,6 @@ package technology.dice.dicewhere.downloader.destination.s3;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Optional;
-import java.util.function.Consumer;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.ResponseInputStream;
@@ -51,10 +50,10 @@ public class S3DownloadSetup {
                           .credentialsProvider(
                               StaticCredentialsProvider.create(
                                   AwsBasicCredentials.create(c.getAwsKeyId(), c.getAwsSecretKey())))
-                          .region(Region.of(c.getAwsRegion()))
-                          .forcePathStyle(true);
-                  c.getEndpoint()
-                      .ifPresent(endpoint -> clientBuilder.endpointOverride(URI.create(endpoint)));
+                          .region(Region.of(c.getAwsRegion()));
+                  c.getEndpoint().ifPresent(
+                      endpoint -> clientBuilder.endpointOverride(URI.create(endpoint))
+                          .forcePathStyle(true));
 
                   return clientBuilder.build();
                 })

--- a/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/destination/s3/S3DownloadSetup.java
+++ b/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/destination/s3/S3DownloadSetup.java
@@ -51,7 +51,8 @@ public class S3DownloadSetup {
                           .credentialsProvider(
                               StaticCredentialsProvider.create(
                                   AwsBasicCredentials.create(c.getAwsKeyId(), c.getAwsSecretKey())))
-                          .region(Region.of(c.getAwsRegion()));
+                          .region(Region.of(c.getAwsRegion()))
+                          .forcePathStyle(true);
                   c.getEndpoint()
                       .ifPresent(endpoint -> clientBuilder.endpointOverride(URI.create(endpoint)));
 


### PR DESCRIPTION
**WHAT**
With the latest commons bump ( [bump](https://github.com/DiceTechnology/dce-commons/commit/14ce96ee272f91e2f041097317263077f09ad40e) ) the **DiceWhereDownloaderScheduleJobTest** started to fail consistently with the following error:

`Received an UnknownHostException when attempting to interact with a service. See cause for the exact endpoint that is failing to resolve. If this is happening on an endpoint that previously worked, there may be a network connectivity issue or your DNS cache could be storing endpoints for too long.`

![Screenshot 2024-02-20 at 16 15 45](https://github.com/DiceTechnology/dice-where/assets/9936714/f9df54f0-f2ab-44a6-aaed-fb6a960e1c9f)

Debugging further we noticed that the issue comes from the **SYNC** AwsClient that is being built on the `dice-where` module.

As a method to fix it, we added `.forcePathStyle(true);` as mentioned on the AWS documentation (https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/examples-s3.html)

`S3Client client = S3Client.builder()
                          .region(Region.US_WEST_2)
                          .endpointOverride(URI.create("https://s3.us-west-2.amazonaws.com"))
                          .forcePathStyle(true)
                          .build();`
