### PR TITLE
PREN-202 Fix Maven Central publishing plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,10 +217,12 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>io.github.gradle-website</groupId>
-            <artifactId>central-publishing-plugin</artifactId>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
             <version>0.7.0</version>
+            <extensions>true</extensions>
             <configuration>
+              <publishingServerId>central</publishingServerId>
               <autoPublish>true</autoPublish>
               <waitUntil>published</waitUntil>
             </configuration>


### PR DESCRIPTION
[PREN-202]

Fixes a broken configuration of the `central-publishing-maven-plugin` plugin.