### PR TITLE
Read secret from env var

### DIFF
--- a/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/source/ipinfosite/IpInfoSiteSource.java
+++ b/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/source/ipinfosite/IpInfoSiteSource.java
@@ -33,7 +33,7 @@ public class IpInfoSiteSource extends BaseUrlSource {
         dataConnection.setRequestMethod("HEAD");
 
         if (dataConnection.getResponseCode() > 299 || dataConnection.getResponseCode() < 200) {
-          throw new DownloaderException("Could not find remote file");
+          throw new DownloaderException("Could not find remote file " + dataConnection.getResponseCode());
         }
 
         long fileSize = dataConnection.getContentLengthLong();

--- a/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/source/maxmindsite/MaxmindSiteSource.java
+++ b/dice-where-downloader-lib/src/main/java/technology/dice/dicewhere/downloader/source/maxmindsite/MaxmindSiteSource.java
@@ -33,7 +33,7 @@ public class MaxmindSiteSource extends BaseUrlSource {
         dataConnection.setRequestMethod("HEAD");
 
         if (dataConnection.getResponseCode() > 299 || dataConnection.getResponseCode() < 200) {
-          throw new DownloaderException("Could not find remote file");
+          throw new DownloaderException("Could not find remote file " + dataConnection.getResponseCode());
         }
 
         long fileSize = dataConnection.getContentLengthLong();

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -7,8 +7,6 @@ import picocli.CommandLine.Parameters;
 import technology.dice.dicewhere.downloader.actions.DownloadExecutionResult;
 import technology.dice.dicewhere.downloader.actions.ipinfo.DownloadIpInfoSite;
 
-import java.util.Optional;
-
 @Command(
     name = "ipinfo-site",
     description = "Downloads the selected IpInfo dataset from IpInfo's website")

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -1,6 +1,5 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -1,5 +1,7 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -12,18 +14,14 @@ import java.util.Optional;
     name = "ipinfo-site",
     description = "Downloads the selected IpInfo dataset from IpInfo's website")
 public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
+  private static final Logger LOG = LoggerFactory.getLogger(DownloadIpInfoSiteCommand.class);
 
   @Option(
-      names = {"-t", "--token"},
-      required = false,
-      description = "The ipinfo download key")
+    names = {"-t", "--token"},
+    required = false,
+    defaultValue = "${env:IPINFO_API_KEY}",
+    description = "The ipinfo download key")
   String token;
-
-  @Option(names = {"-ak", "--api-key"},
-          required = false,
-          defaultValue = "${env:API_KEY}",
-          description = "The ipinfo download key (env var)")
-  private String apiKey;
 
   @Parameters(
       index = "0",
@@ -33,12 +31,8 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-    String secretToken = Optional.of(apiKey)
-            .or(() -> Optional.of(token))
-            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
-
     return new DownloadIpInfoSite(
-            noCheckMd5, overwrite, verbose, dataset, format, secretToken, destination)
+            noCheckMd5, overwrite, verbose, dataset, format, token, destination)
             .execute();
   }
 }

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -1,5 +1,7 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -12,6 +14,8 @@ import java.util.Optional;
     name = "ipinfo-site",
     description = "Downloads the selected IpInfo dataset from IpInfo's website")
 public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DownloadIpInfoSiteCommand.class);
   @Option(
       names = {"-t", "--token"},
       required = false,
@@ -33,7 +37,14 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
   @Override
   public DownloadExecutionResult execute() {
     String secretToken = Optional.of(apiKey)
-            .or(() -> Optional.of(token))
+            .map(v -> {
+              LOG.info("-ak param used");
+              return v;
+            })
+            .or(() -> {
+              LOG.info("-t param used");
+                return Optional.of(token);
+            })
             .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
 
     return new DownloadIpInfoSite(

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -16,17 +16,13 @@ import java.util.Optional;
 public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
   private static final Logger LOG = LoggerFactory.getLogger(DownloadIpInfoSiteCommand.class);
+
+  private static final String ENV_VAR_API_KEY = "IPINFO_API_KEY";
   @Option(
       names = {"-t", "--token"},
       required = false,
       description = "The ipinfo download key")
   String token;
-
-  @Option(names = {"-ak", "--api-key"},
-          required = false,
-          defaultValue = "${env:IPINFO_API_KEY}",
-          description = "The ipinfo download key (env var)")
-  private String apiKey;
 
   @Parameters(
       index = "0",
@@ -36,15 +32,12 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-    String secretToken = Optional.of(apiKey)
+    String secretToken = Optional.of(System.getenv(ENV_VAR_API_KEY))
             .map(v -> {
               LOG.info("-ak param used");
               return v;
             })
-            .or(() -> {
-              LOG.info("-t param used");
-                return Optional.of(token);
-            })
+            .or(() -> Optional.of(token))
             .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
 
     return new DownloadIpInfoSite(

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -38,7 +38,7 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
               return v;
             })
             .or(() -> Optional.of(token))
-            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
+            .orElseThrow(() -> new IllegalStateException("Token param or api key env var should be provided"));
 
     return new DownloadIpInfoSite(
             noCheckMd5, overwrite, verbose, dataset, format, secretToken, destination)

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -19,10 +19,11 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
       description = "The ipinfo download key")
   String token;
 
-    @Option(names = "--token:env",
-            required = false,
-            description = "The ipinfo download key env variable")
-    private String tokenEnvVariable;
+  @Option(names = {"-ak", "--api-key"},
+          required = false,
+          defaultValue = "${env:API_KEY}",
+          description = "The ipinfo download key (env var)")
+  private String apiKey;
 
   @Parameters(
       index = "0",
@@ -32,9 +33,9 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-      var secretToken = Optional.ofNullable(token)
-              .or(() -> Optional.ofNullable(System.getenv(tokenEnvVariable)))
-              .orElseThrow(() -> new IllegalStateException("Token param or api key env var should be provided"));
+    String secretToken = Optional.of(apiKey)
+            .or(() -> Optional.of(token))
+            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
 
     return new DownloadIpInfoSite(
             noCheckMd5, overwrite, verbose, dataset, format, secretToken, destination)

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -18,10 +18,10 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
       description = "The ipinfo download key")
   String token;
 
-  @Option(names = {"-k", "--api-key"},
+  @Option(names = {"-ak", "--api-key"},
           required = false,
           defaultValue = "${env:API_KEY}",
-          description = "API key")
+          description = "The ipinfo download key (env var)")
   private String apiKey;
 
   @Parameters(

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -1,6 +1,5 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -11,9 +10,6 @@ import technology.dice.dicewhere.downloader.actions.ipinfo.DownloadIpInfoSite;
     name = "ipinfo-site",
     description = "Downloads the selected IpInfo dataset from IpInfo's website")
 public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
-    static {
-        LoggerFactory.getLogger(DownloadIpInfoSiteCommand.class);
-    }
 
     @Option(
     names = {"-t", "--token"},

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -1,7 +1,5 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -15,14 +13,16 @@ import java.util.Optional;
     description = "Downloads the selected IpInfo dataset from IpInfo's website")
 public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DownloadIpInfoSiteCommand.class);
-
-  private static final String ENV_VAR_API_KEY = "IPINFO_API_KEY";
   @Option(
       names = {"-t", "--token"},
       required = false,
       description = "The ipinfo download key")
   String token;
+
+    @Option(names = "--token:env",
+            required = false,
+            description = "The ipinfo download key env variable")
+    private String tokenEnvVariable;
 
   @Parameters(
       index = "0",
@@ -32,13 +32,9 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-    String secretToken = Optional.of(System.getenv(ENV_VAR_API_KEY))
-            .map(v -> {
-              LOG.info("-ak param used");
-              return v;
-            })
-            .or(() -> Optional.of(token))
-            .orElseThrow(() -> new IllegalStateException("Token param or api key env var should be provided"));
+      var secretToken = Optional.ofNullable(token)
+              .or(() -> Optional.ofNullable(System.getenv(tokenEnvVariable)))
+              .orElseThrow(() -> new IllegalStateException("Token param or api key env var should be provided"));
 
     return new DownloadIpInfoSite(
             noCheckMd5, overwrite, verbose, dataset, format, secretToken, destination)

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -14,9 +14,11 @@ import java.util.Optional;
     name = "ipinfo-site",
     description = "Downloads the selected IpInfo dataset from IpInfo's website")
 public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
-  private static final Logger LOG = LoggerFactory.getLogger(DownloadIpInfoSiteCommand.class);
+    static {
+        LoggerFactory.getLogger(DownloadIpInfoSiteCommand.class);
+    }
 
-  @Option(
+    @Option(
     names = {"-t", "--token"},
     required = false,
     defaultValue = "${env:IPINFO_API_KEY}",

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -20,7 +20,7 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
   @Option(names = {"-ak", "--api-key"},
           required = false,
-          defaultValue = "${env:API_KEY}",
+          defaultValue = "${env:IPINFO_API_KEY}",
           description = "The ipinfo download key (env var)")
   private String apiKey;
 

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadIpInfoSiteCommand.java
@@ -6,15 +6,23 @@ import picocli.CommandLine.Parameters;
 import technology.dice.dicewhere.downloader.actions.DownloadExecutionResult;
 import technology.dice.dicewhere.downloader.actions.ipinfo.DownloadIpInfoSite;
 
+import java.util.Optional;
+
 @Command(
     name = "ipinfo-site",
     description = "Downloads the selected IpInfo dataset from IpInfo's website")
 public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
   @Option(
       names = {"-t", "--token"},
-      required = true,
+      required = false,
       description = "The ipinfo download key")
   String token;
+
+  @Option(names = {"-k", "--api-key"},
+          required = false,
+          defaultValue = "${env:API_KEY}",
+          description = "API key")
+  private String apiKey;
 
   @Parameters(
       index = "0",
@@ -24,8 +32,12 @@ public class DownloadIpInfoSiteCommand extends IpInfoBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
+    String secretToken = Optional.of(apiKey)
+            .or(() -> Optional.of(token))
+            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
+
     return new DownloadIpInfoSite(
-            noCheckMd5, overwrite, verbose, dataset, format, token, destination)
-        .execute();
+            noCheckMd5, overwrite, verbose, dataset, format, secretToken, destination)
+            .execute();
   }
 }

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -1,5 +1,7 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -13,17 +15,14 @@ import java.util.Optional;
     description = "Downloads the selected Maxmind edition of a database from Maxmind's website")
 public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
-  @Option(
-          names = {"-k", "--key"},
-          required = false,
-          description = "The maxmind download key")
-  String key;
+  private static final Logger LOG = LoggerFactory.getLogger(DownloadMaxmindSiteCommand.class);
 
-  @Option(names = {"-ak", "--api-key"},
-          required = false,
-          defaultValue = "${env:API_KEY}",
-          description = "The maxmind download key (env var)")
-  private String apiKey;
+  @Option(
+        names = {"-k", "--key"},
+        required = false,
+        defaultValue = "${env:MAXMIND_API_KEY}",
+        description = "The maxmind download key")
+  String key;
 
   @Parameters(
       index = "0",
@@ -33,12 +32,8 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-    String secretToken = Optional.of(apiKey)
-            .or(() -> Optional.of(key))
-            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
-
     return new DownloadMaxmindSite(
-            noCheckMd5, overwrite, verbose, edition, database, format, secretToken, destination)
+            noCheckMd5, overwrite, verbose, edition, database, format, key, destination)
         .execute();
   }
 }

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -13,17 +13,13 @@ import java.util.Optional;
     description = "Downloads the selected Maxmind edition of a database from Maxmind's website")
 public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
+  private static final String ENV_VAR_API_KEY = "MAXMIND_API_KEY";
+
   @Option(
       names = {"-k", "--key"},
       required = true,
       description = "The maxmind download key")
   String key;
-
-  @Option(names = {"-ak", "--api-key"},
-          required = false,
-          defaultValue = "${env:MAXMIND_API_KEY}",
-          description = "The maxmind download key (env var)")
-  private String apiKey;
 
   @Parameters(
       index = "0",
@@ -33,7 +29,7 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-    String secretToken = Optional.of(apiKey)
+    String secretToken = Optional.of(System.getenv(ENV_VAR_API_KEY))
             .or(() -> Optional.of(key))
             .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
 

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -17,7 +17,7 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
   @Option(
       names = {"-k", "--key"},
-      required = true,
+      required = false,
       description = "The maxmind download key")
   String key;
 
@@ -31,7 +31,7 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
   public DownloadExecutionResult execute() {
     String secretToken = Optional.of(System.getenv(ENV_VAR_API_KEY))
             .or(() -> Optional.of(key))
-            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
+            .orElseThrow(() -> new IllegalStateException("Token param or api key env var should be provided"));
 
     return new DownloadMaxmindSite(
             noCheckMd5, overwrite, verbose, edition, database, format, secretToken, destination)

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -1,6 +1,5 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
@@ -11,10 +10,6 @@ import technology.dice.dicewhere.downloader.actions.maxmind.DownloadMaxmindSite;
     name = "maxmind-site",
     description = "Downloads the selected Maxmind edition of a database from Maxmind's website")
 public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
-
-    static {
-        LoggerFactory.getLogger(DownloadMaxmindSiteCommand.class);
-    }
 
     @Option(
         names = {"-k", "--key"},

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -7,8 +7,6 @@ import picocli.CommandLine.Parameters;
 import technology.dice.dicewhere.downloader.actions.DownloadExecutionResult;
 import technology.dice.dicewhere.downloader.actions.maxmind.DownloadMaxmindSite;
 
-import java.util.Optional;
-
 @Command(
     name = "maxmind-site",
     description = "Downloads the selected Maxmind edition of a database from Maxmind's website")

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -1,6 +1,5 @@
 package technology.dice.dicewhere.downloader.picocli.commands;
 
-import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -15,9 +14,11 @@ import java.util.Optional;
     description = "Downloads the selected Maxmind edition of a database from Maxmind's website")
 public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
-  private static final Logger LOG = LoggerFactory.getLogger(DownloadMaxmindSiteCommand.class);
+    static {
+        LoggerFactory.getLogger(DownloadMaxmindSiteCommand.class);
+    }
 
-  @Option(
+    @Option(
         names = {"-k", "--key"},
         required = false,
         defaultValue = "${env:MAXMIND_API_KEY}",

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -6,6 +6,8 @@ import picocli.CommandLine.Parameters;
 import technology.dice.dicewhere.downloader.actions.DownloadExecutionResult;
 import technology.dice.dicewhere.downloader.actions.maxmind.DownloadMaxmindSite;
 
+import java.util.Optional;
+
 @Command(
     name = "maxmind-site",
     description = "Downloads the selected Maxmind edition of a database from Maxmind's website")
@@ -17,6 +19,12 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
       description = "The maxmind download key")
   String key;
 
+  @Option(names = {"-ak", "--api-key"},
+          required = false,
+          defaultValue = "${env:API_KEY}",
+          description = "The maxmind download key (env var)")
+  private String apiKey;
+
   @Parameters(
       index = "0",
       description =
@@ -25,8 +33,12 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
+    String secretToken = Optional.of(apiKey)
+            .or(() -> Optional.of(key))
+            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
+
     return new DownloadMaxmindSite(
-            noCheckMd5, overwrite, verbose, edition, database, format, key, destination)
+            noCheckMd5, overwrite, verbose, edition, database, format, secretToken, destination)
         .execute();
   }
 }

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -19,10 +19,11 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
           description = "The maxmind download key")
   String key;
 
-  @Option(names = "--key:env",
+  @Option(names = {"-ak", "--api-key"},
           required = false,
-          description = "The maxmind download key env variable")
-  String keyEnvVariable;
+          defaultValue = "${env:API_KEY}",
+          description = "The maxmind download key (env var)")
+  private String apiKey;
 
   @Parameters(
       index = "0",
@@ -32,9 +33,9 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-    var secretToken = Optional.ofNullable(key)
-            .or(() -> Optional.ofNullable(System.getenv(keyEnvVariable)))
-            .orElseThrow(() -> new IllegalStateException("Key param or api key env var should be provided"));
+    String secretToken = Optional.of(apiKey)
+            .or(() -> Optional.of(key))
+            .orElseThrow(() -> new IllegalStateException("Token or api key parameters should be provided"));
 
     return new DownloadMaxmindSite(
             noCheckMd5, overwrite, verbose, edition, database, format, secretToken, destination)

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -13,13 +13,16 @@ import java.util.Optional;
     description = "Downloads the selected Maxmind edition of a database from Maxmind's website")
 public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
-  private static final String ENV_VAR_API_KEY = "MAXMIND_API_KEY";
-
   @Option(
-      names = {"-k", "--key"},
-      required = false,
-      description = "The maxmind download key")
+          names = {"-k", "--key"},
+          required = false,
+          description = "The maxmind download key")
   String key;
+
+  @Option(names = "--key:env",
+          required = false,
+          description = "The maxmind download key env variable")
+  String keyEnvVariable;
 
   @Parameters(
       index = "0",
@@ -29,9 +32,9 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
   @Override
   public DownloadExecutionResult execute() {
-    String secretToken = Optional.of(System.getenv(ENV_VAR_API_KEY))
-            .or(() -> Optional.of(key))
-            .orElseThrow(() -> new IllegalStateException("Token param or api key env var should be provided"));
+    var secretToken = Optional.ofNullable(key)
+            .or(() -> Optional.ofNullable(System.getenv(keyEnvVariable)))
+            .orElseThrow(() -> new IllegalStateException("Key param or api key env var should be provided"));
 
     return new DownloadMaxmindSite(
             noCheckMd5, overwrite, verbose, edition, database, format, secretToken, destination)

--- a/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
+++ b/dice-where-downloader/src/main/java/technology/dice/dicewhere/downloader/picocli/commands/DownloadMaxmindSiteCommand.java
@@ -21,7 +21,7 @@ public class DownloadMaxmindSiteCommand extends MaxmindBaseCommand {
 
   @Option(names = {"-ak", "--api-key"},
           required = false,
-          defaultValue = "${env:API_KEY}",
+          defaultValue = "${env:MAXMIND_API_KEY}",
           description = "The maxmind download key (env var)")
   private String apiKey;
 


### PR DESCRIPTION
**WHAT**
Read secrets from env var. This change is backwards compatible, tokens can be provided as command args as well, same way it has been done so far.

**WHY**
To have more secure way of passing tokens.

**AC**
When env var is present it is used as token 

**TESTING:**
TASK RUNS SUCCESSFULLY:
<img width="1613" height="569" alt="Screenshot 2025-09-11 at 18 13 07" src="https://github.com/user-attachments/assets/81191683-a69a-4f10-8e0c-cfe81df0d94c" />
<img width="1615" height="533" alt="Screenshot 2025-09-11 at 18 13 15" src="https://github.com/user-attachments/assets/97d529f6-3554-4cdd-b718-3a7ed76b138f" />
FILES PLACED SUCCESSFULLY:
<img width="1647" height="423" alt="Screenshot 2025-09-11 at 18 14 45" src="https://github.com/user-attachments/assets/b1f2af76-2a01-4688-a904-733c30f5396e" />

TASK DEFINITION CONFIGURATION - CURRENTLY THE SECRET IS EXPOSED AS PLAINTEXT HERE:
<img width="1091" height="841" alt="Screenshot 2025-09-11 at 18 27 56" src="https://github.com/user-attachments/assets/2022f994-e5f7-4251-be39-f6e775f64ad6" />
<img width="1116" height="846" alt="Screenshot 2025-09-11 at 18 30 28" src="https://github.com/user-attachments/assets/55af6a82-acfa-4264-83ff-82904fa09db5" />
